### PR TITLE
Specify babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "webpack": "^1.11.0"
   },
   "devDependencies": {
-    "babel": "*",
+    "babel": "^5.8.29",
     "babel-plugin-react-hotify": "^0.1.1",
     "core-js": "^0.9.18",
     "http-hash": "^2.0.0",


### PR DESCRIPTION
The example doesn't work with Babel 6, yet:

```
> NODE_ENV=hot node ./boot.js

module.js:338
    throw err;
    ^

Error: Cannot find module 'babel/register'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/inyono/Projects/react-redux-tiny/boot.js:3:2)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:475:10)
```

I therefore specified the babel version in `package.json`
